### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Rave Language</h1>
 
 Rave is a statically typed, compiled, procedural, general-purpose programming language. We (core contributors) took
-inspiration from C, C++, Rust, Assembly and we are making an easy-to-use but low-level language.
+inspiration from C, C++, Rust and Assembly, making an easy-to-use but low-level language.
 
 ## "Hello, world!" Example
 
@@ -24,7 +24,7 @@ main: int {
 
 ## Building/Running
 
-Rename `base.dub.json` to `dub.json` and change the flags. Then run `dub build`
+Copy `base.dub.json` to `dub.json` and change the flags (if you need to change them). Then run `dub build`
 
 ## Goals
 


### PR DESCRIPTION
Second sentence: changed to be more natural (not sure about that, but better than what it was) and with less repetition
in `Building/Running` : changed Rename to Copy because if you rename a file, git will remove the `base.dub.json` file which is necessary for new contributors to get started. I intended `base.dub.json` to be a static file that doesn't change and for each contributor to have their own git-ignored `dub.json` that is specific to their system.